### PR TITLE
add compatability to react 16.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { View, WebView, Text }  from 'react-native';
 import qr from 'qr.js';
+import PropTypes from 'prop-types';
 
 export class BarCode extends Component {
     render() {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/fabianbormann/react-native-qr-barcode/blob/master/README.md",
   "dependencies": {
     "jsbarcode": "^3.5.0-beta",
+    "prop-types": "^15.6.0",
     "qr.js": "0.0.0"
   }
 }


### PR DESCRIPTION
Import PropTypes from the new prop-types package instead of from react.